### PR TITLE
Update asset paths to relative in Natsu page

### DIFF
--- a/pages/personagens/natsu.html
+++ b/pages/personagens/natsu.html
@@ -42,28 +42,28 @@
     <div class="habilidade-card rugido-fogo" tabindex="0">
       <h3>🔥 Rugido do Dragão de Fogo</h3>
       <p>Natsu cospe uma poderosa rajada de fogo em forma de rugido, varrendo tudo à frente com pura força dracônica.</p>
-      <img src="/assets/img/GIFs/Karyū no Hōkō.gif" alt="GIF da técnica Rugido do Dragão de Fogo" />
+      <img src="../../assets/img/GIFs/Karyū no Hōkō.gif" alt="GIF da técnica Rugido do Dragão de Fogo" />
     </div>
 
     <!-- Chama Relâmpago -->
     <div class="habilidade-card chama-raio" tabindex="0">
       <h3>⚡ Chama Relâmpago</h3>
       <p>Natsu combina seu fogo com eletricidade para causar ataques mais rápidos e intensos.</p>
-      <img src="/assets/img/GIFs/Fire Dragon Lightning Mode.gif" alt="Gif da habilidade Chama Relâmpago" />
+      <img src="../../assets/img/GIFs/Fire Dragon Lightning Mode.gif" alt="Gif da habilidade Chama Relâmpago" />
     </div>
 
     <!-- Modo Rei Dragão do Fogo -->
     <div class="habilidade-card modo-rei" tabindex="0">
       <h3>🔥👑 Modo Rei Dragão do Fogo</h3>
       <p>Forma suprema de Natsu, canalizando o poder de Igneel em um ataque devastador com chamas reais.</p>
-      <img src="/assets/img/GIFs/Modo Rei Dragão do Fogo.gif" alt="GIF ilustrando Modo Rei Dragão do Fogo" />
+      <img src="../../assets/img/GIFs/Modo Rei Dragão do Fogo.gif" alt="GIF ilustrando Modo Rei Dragão do Fogo" />
     </div>
 
     <!-- Punho do Dragão de Fogo -->
     <div class="habilidade-card corpo-flamejante" tabindex="0">
       <h3>🥊🔥 Punho do Dragão de Fogo</h3>
       <p>Estilo de luta de Natsu com socos e chutes envoltos em chamas intensas.</p>
-      <img src="/assets/img/GIFs/Fire Dragon's Iron Fist.webp" alt="GIF do Punho do Dragão de Fogo" />
+      <img src="../../assets/img/GIFs/Fire Dragon's Iron Fist.webp" alt="GIF do Punho do Dragão de Fogo" />
     </div>
 
   </div>
@@ -73,11 +73,11 @@
 
     <section class="galeria" aria-labelledby="galeria-title">
       <h2 id="galeria-title">Galeria</h2>
-      <img class="galeria-img" src="/assets/img/natsu/natsu-happy.png" alt="Natsu em pose amigável com Happy" />
-      <img class="galeria-img" src="/assets/img/natsu/natsu-gray.png" alt="Natsu competindo com Gray" />
-      <img class="galeria-img" src="/assets/img/natsu/guilda-fairy-tail.png" alt="Cenário da guilda Fairy Tail" />
-      <img class="galeria-img" src="/assets/img/natsu/natsu-perfil.png" alt="Imagem de perfil do Natsu" />
-      <img class="galeria-img" src="/assets/img/natsu/natsu-rei-dragao.png" alt="Natsu no modo Rei Dragão do Fogo" />
+      <img class="galeria-img" src="../../assets/img/natsu/natsu-happy.png" alt="Natsu em pose amigável com Happy" />
+      <img class="galeria-img" src="../../assets/img/natsu/natsu-gray.png" alt="Natsu competindo com Gray" />
+      <img class="galeria-img" src="../../assets/img/natsu/guilda-fairy-tail.png" alt="Cenário da guilda Fairy Tail" />
+      <img class="galeria-img" src="../../assets/img/natsu/natsu-perfil.png" alt="Imagem de perfil do Natsu" />
+      <img class="galeria-img" src="../../assets/img/natsu/natsu-rei-dragao.png" alt="Natsu no modo Rei Dragão do Fogo" />
     </section>
 
     <div class="flip-card" role="region" aria-label="Habilidade do Natsu">
@@ -99,8 +99,8 @@
   <div class="fogo-particles" aria-hidden="true"></div>
 
   <!-- Áudios -->
-  <audio id="narracao-natsu" src="/assets/audio/natsu/natsu-narracao.v01.wav" preload="auto"></audio>
-  <audio id="som-fogo" src="/assets/audio/fire.mp3" preload="auto"></audio>
+  <audio id="narracao-natsu" src="../../assets/audio/natsu/natsu-narracao.v01.wav" preload="auto"></audio>
+  <audio id="som-fogo" src="../../assets/audio/fire.mp3" preload="auto"></audio>
 
   <!-- Lightbox -->
   <div id="lightbox" class="lightbox hidden">


### PR DESCRIPTION
Changed image and audio asset paths from absolute to relative in personagens/natsu.html to improve compatibility with different directory structures and deployment environments.