### PR TITLE
Fix image paths and HTML indentation for personagens

### DIFF
--- a/css/natsu.css
+++ b/css/natsu.css
@@ -14,7 +14,7 @@ body::before {
   left: 0;
   width: 100%;
   height: 100%;
-  background-image: url(/assets/img/natsu/natsu-bg.png); /* Fundo do personagem */
+  background-image: url('../../assets/img/natsu/natsu-bg.png'); /* Fundo do personagem */
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;

--- a/pages/personagens/gray.html
+++ b/pages/personagens/gray.html
@@ -49,7 +49,7 @@
     <img src="../../assets/img/gray/Gray-Fullbuster-no-Gelo.png" alt="Gray 1">
     <img src="../../assets/img/gray/Gray-Invocando-Gelo.png" alt="Gray 2">
     <img src="../../assets/img/gray/Mestre-do-Gelo.png" alt="Gray 3">
-     <img src="../../assets/img/gray/Gray-Fullbuster Determinado-simple_compose_01.png" alt="Gray 4">
+    <img src="../../assets/img/gray/Gray-Fullbuster Determinado-simple_compose_01.png" alt="Gray 4">
   </section>
 
   <!-- Lightbox (aparece ao clicar na imagem) -->

--- a/pages/personagens/natsu.html
+++ b/pages/personagens/natsu.html
@@ -33,43 +33,41 @@
       <button id="btn-narrar" aria-label="Ouvir biografia de Natsu Dragneel">Ouvir biografia</button>
     </section>
 
-   <section class="habilidades" aria-labelledby="habilidades-title">
-  <h2 id="habilidades-title">Habilidades</h2>
+    <section class="habilidades" aria-labelledby="habilidades-title">
+      <h2 id="habilidades-title">Habilidades</h2>
 
-  <div class="habilidades-lista">
+      <div class="habilidades-lista">
 
-    <!-- Rugido do Dragão de Fogo -->
-    <div class="habilidade-card rugido-fogo" tabindex="0">
-      <h3>🔥 Rugido do Dragão de Fogo</h3>
-      <p>Natsu cospe uma poderosa rajada de fogo em forma de rugido, varrendo tudo à frente com pura força dracônica.</p>
-      <img src="../../assets/img/GIFs/Karyū no Hōkō.gif" alt="GIF da técnica Rugido do Dragão de Fogo" />
-    </div>
+        <!-- Rugido do Dragão de Fogo -->
+        <div class="habilidade-card rugido-fogo" tabindex="0">
+          <h3>🔥 Rugido do Dragão de Fogo</h3>
+          <p>Natsu cospe uma poderosa rajada de fogo em forma de rugido, varrendo tudo à frente com pura força dracônica.</p>
+          <img src="../../assets/img/GIFs/Karyū no Hōkō.gif" alt="GIF da técnica Rugido do Dragão de Fogo" />
+        </div>
 
-    <!-- Chama Relâmpago -->
-    <div class="habilidade-card chama-raio" tabindex="0">
-      <h3>⚡ Chama Relâmpago</h3>
-      <p>Natsu combina seu fogo com eletricidade para causar ataques mais rápidos e intensos.</p>
-      <img src="../../assets/img/GIFs/Fire Dragon Lightning Mode.gif" alt="Gif da habilidade Chama Relâmpago" />
-    </div>
+        <!-- Chama Relâmpago -->
+        <div class="habilidade-card chama-raio" tabindex="0">
+          <h3>⚡ Chama Relâmpago</h3>
+          <p>Natsu combina seu fogo com eletricidade para causar ataques mais rápidos e intensos.</p>
+          <img src="../../assets/img/GIFs/Fire Dragon Lightning Mode.gif" alt="Gif da habilidade Chama Relâmpago" />
+        </div>
 
-    <!-- Modo Rei Dragão do Fogo -->
-    <div class="habilidade-card modo-rei" tabindex="0">
-      <h3>🔥👑 Modo Rei Dragão do Fogo</h3>
-      <p>Forma suprema de Natsu, canalizando o poder de Igneel em um ataque devastador com chamas reais.</p>
-      <img src="../../assets/img/GIFs/Modo Rei Dragão do Fogo.gif" alt="GIF ilustrando Modo Rei Dragão do Fogo" />
-    </div>
+        <!-- Modo Rei Dragão do Fogo -->
+        <div class="habilidade-card modo-rei" tabindex="0">
+          <h3>🔥👑 Modo Rei Dragão do Fogo</h3>
+          <p>Forma suprema de Natsu, canalizando o poder de Igneel em um ataque devastador com chamas reais.</p>
+          <img src="../../assets/img/GIFs/Modo Rei Dragão do Fogo.gif" alt="GIF ilustrando Modo Rei Dragão do Fogo" />
+        </div>
 
-    <!-- Punho do Dragão de Fogo -->
-    <div class="habilidade-card corpo-flamejante" tabindex="0">
-      <h3>🥊🔥 Punho do Dragão de Fogo</h3>
-      <p>Estilo de luta de Natsu com socos e chutes envoltos em chamas intensas.</p>
-      <img src="../../assets/img/GIFs/Fire Dragon's Iron Fist.webp" alt="GIF do Punho do Dragão de Fogo" />
-    </div>
+        <!-- Punho do Dragão de Fogo -->
+        <div class="habilidade-card corpo-flamejante" tabindex="0">
+          <h3>🥊🔥 Punho do Dragão de Fogo</h3>
+          <p>Estilo de luta de Natsu com socos e chutes envoltos em chamas intensas.</p>
+          <img src="../../assets/img/GIFs/Fire Dragon's Iron Fist.webp" alt="GIF do Punho do Dragão de Fogo" />
+        </div>
 
-  </div>
-</section>
-
-
+      </div>
+    </section>
 
     <section class="galeria" aria-labelledby="galeria-title">
       <h2 id="galeria-title">Galeria</h2>


### PR DESCRIPTION
Updated the background image path in natsu.css for correct relative referencing. Fixed indentation in natsu.html for the habilidades section and corrected a minor whitespace issue in gray.html image markup.